### PR TITLE
Enable building and headless tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.10)
+project(ODE_VSG_examples)
+enable_testing()
+
+option(USE_VSG "Build with VulkanSceneGraph" ON)
+
+add_executable(wheeled_simulation wheeled_simulation.cpp)
+# Include headers
+target_include_directories(wheeled_simulation PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(ODE REQUIRED ode)
+
+target_link_libraries(wheeled_simulation PRIVATE ${ODE_LIBRARIES})
+target_include_directories(wheeled_simulation PRIVATE ${ODE_INCLUDE_DIRS})
+
+if(USE_VSG)
+    find_package(vsg REQUIRED)
+    target_link_libraries(wheeled_simulation PRIVATE vsg::vsg)
+    target_compile_definitions(wheeled_simulation PRIVATE USE_VSG)
+endif()
+
+# Test program (no VSG needed)
+add_executable(headless_test tests/headless_test.cpp)
+target_include_directories(headless_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+target_link_libraries(headless_test PRIVATE ${ODE_LIBRARIES})
+add_test(NAME headless COMMAND headless_test)

--- a/README.md
+++ b/README.md
@@ -1,2 +1,31 @@
 # ODE-VSG-examples
-Examples for robotic framework based on ODE dynamics engine and VSG rendering
+
+Examples for a robotic framework based on the Open Dynamics Engine (ODE) and the VulkanSceneGraph (VSG).
+
+## Building
+
+This project uses **CMake**. ODE is required for all builds while VSG is optional.
+When `USE_VSG=ON` (default) the example will open a graphical window. When disabled
+only the physics simulation is run in a headless mode.
+
+```bash
+# install dependencies (Ubuntu)
+sudo apt-get install build-essential cmake libode-dev
+# VSG is optional and can be built from source
+```
+
+```bash
+mkdir build && cd build
+cmake .. -DUSE_VSG=OFF  # set ON if VSG is available
+make
+ctest
+```
+
+The headless test runs a short simulation and verifies that the robot body
+remains above the ground.
+
+To run the graphical demo (with VSG installed):
+
+```bash
+./wheeled_simulation
+```

--- a/include/ODEPhysicsModule.h
+++ b/include/ODEPhysicsModule.h
@@ -1,0 +1,138 @@
+#pragma once
+#include <ode/ode.h>
+
+//////////////////////////////////////////////////////////////////
+/// Physics module: wraps all ODE setup, stepping, and cleanup ///
+//////////////////////////////////////////////////////////////////
+class ODEPhysicsModule {
+public:
+    ODEPhysicsModule()
+    {
+        dInitODE();
+        world        = dWorldCreate();
+        space        = dHashSpaceCreate(0);
+        contactgroup = dJointGroupCreate(0);
+        dWorldSetGravity(world, 0, 0, -9.81);
+
+        // Ground plane at z=0
+        ground = dCreatePlane(space, 0, 0, 1, 0);
+    }
+
+    ~ODEPhysicsModule()
+    {
+        dJointGroupDestroy(contactgroup);
+        dSpaceDestroy(space);
+        dWorldDestroy(world);
+        dCloseODE();
+    }
+
+    /// Build the robot: body + 4 wheels + hinge‐motors + geoms
+    void createRobot()
+    {
+        // 1) chassis body
+        body = dBodyCreate(world);
+        dMass m;
+        dMassSetBoxTotal(&m, 1.0, 1.0, 1.0, 1.0);
+        dBodySetMass(body, &m);
+        dBodySetPosition(body, 0, 0, 1.0);
+
+        // geom for collisions
+        bodyGeom = dCreateBox(space, 1.0, 1.0, 1.0);
+        dGeomSetBody(bodyGeom, body);
+
+        // 2) wheels
+        for (int i = 0; i < 4; ++i) {
+            // physics body + mass
+            wheels[i] = dBodyCreate(world);
+            dMass mw;
+            dMassSetSphereTotal(&mw, 0.1, 0.2);
+            dBodySetMass(wheels[i], &mw);
+
+            // position them at the four corners
+            double x = (i % 2 == 0) ?  0.5 : -0.5;
+            double y = (i <  2) ?  0.5 : -0.5;
+            dBodySetPosition(wheels[i], x, y, 0.5);
+
+            // collision geom
+            wheelGeoms[i] = dCreateSphere(space, 0.2);
+            dGeomSetBody(wheelGeoms[i], wheels[i]);
+
+            // hinge joint: **axis = Y** for rolling forward/backward  ← FIX
+            joints[i] = dJointCreateHinge(world, 0);
+            dJointAttach(joints[i], body, wheels[i]);
+            dJointSetHingeAnchor(joints[i], x, y, 0.5);
+            dJointSetHingeAxis(joints[i], 0, 1, 0);   // ← FIX: horizontal axis
+
+            // give it a motor: target vel = 1 rad/s, max torque = 10 Nm
+            dJointSetHingeParam(joints[i], dParamVel, 1.0);
+            dJointSetHingeParam(joints[i], dParamFMax, 10.0);
+        }
+    }
+
+    /// Advance the physics by one fixed time step (10 ms)
+    void step()
+    {
+        // collide
+        dSpaceCollide(space, this, &ODEPhysicsModule::nearCallback);
+        // integrate
+        dWorldStep(world, 0.01);
+        // remove all temporary contact joints
+        dJointGroupEmpty(contactgroup);
+    }
+
+    // Getters for rendering sync:
+    const dReal* getBodyPosition()   const { return dBodyGetPosition(body);   }
+    const dReal* getBodyRotation()   const { return dBodyGetRotation(body);   }
+    const dReal* getWheelPosition(int i) const { return dBodyGetPosition(wheels[i]); }
+    const dReal* getWheelRotation(int i) const { return dBodyGetRotation(wheels[i]); }
+
+private:
+    /// ODE collision callback: create contact joints with friction/ERP/CFM
+    static void nearCallback(void* data, dGeomID o1, dGeomID o2)
+    {
+        ODEPhysicsModule* self = static_cast<ODEPhysicsModule*>(data);
+        dBodyID b1 = dGeomGetBody(o1);
+        dBodyID b2 = dGeomGetBody(o2);
+        if (b1 && b2 && dAreConnectedExcluding(b1, b2, dJointTypeContact))
+            return;
+
+        const int MAXC = 10;
+        dContact contact[MAXC];
+        int n = dCollide(o1, o2, MAXC, &contact[0].geom, sizeof(dContact));
+        if (n > 0) {
+            for (int i = 0; i < n; ++i) {
+                contact[i].surface.mode     = dContactSlip1     |
+                                               dContactSlip2     |
+                                               dContactSoftERP   |
+                                               dContactSoftCFM   |
+                                               dContactApprox1;
+                contact[i].surface.mu       = 0.5;
+                contact[i].surface.slip1    = 0.02;
+                contact[i].surface.slip2    = 0.02;
+                contact[i].surface.soft_erp = 0.1;
+                contact[i].surface.soft_cfm = 0.01;
+
+                // create the contact joint
+                dJointID c = dJointCreateContact(self->world,
+                                                  self->contactgroup,
+                                                  &contact[i]);
+                dJointAttach(c, b1, b2);
+            }
+        }
+    }
+
+    dWorldID       world;
+    dSpaceID       space;
+    dJointGroupID  contactgroup;
+    dGeomID        ground;
+
+    // chassis
+    dBodyID        body;
+    dGeomID        bodyGeom;
+
+    // wheels
+    dBodyID        wheels[4];
+    dGeomID        wheelGeoms[4];
+    dJointID       joints[4];
+};
+

--- a/tests/headless_test.cpp
+++ b/tests/headless_test.cpp
@@ -1,0 +1,13 @@
+#include "../include/ODEPhysicsModule.h"
+#include <cassert>
+#include <iostream>
+
+int main() {
+    ODEPhysicsModule physics;
+    physics.createRobot();
+    for (int i = 0; i < 10; ++i) physics.step();
+    const dReal* pos = physics.getBodyPosition();
+    assert(pos[2] > 0.5); // body should stay above ground
+    std::cout << "z=" << pos[2] << std::endl;
+    return 0;
+}

--- a/wheeled_simulation.cpp
+++ b/wheeled_simulation.cpp
@@ -1,145 +1,15 @@
-#include <ode/ode.h>
+#include "ODEPhysicsModule.h"
+#include <iostream>
+
+#ifdef USE_VSG
 #include <vsg/all.h>
 #include <vsg/viewer/Trackball.h>
-
-//////////////////////////////////////////////////////////////////
-/// Physics module: wraps all ODE setup, stepping, and cleanup ///
-//////////////////////////////////////////////////////////////////
-class ODEPhysicsModule {
-public:
-    ODEPhysicsModule()
-    {
-        dInitODE();
-        world        = dWorldCreate();
-        space        = dHashSpaceCreate(0);
-        contactgroup = dJointGroupCreate(0);
-        dWorldSetGravity(world, 0, 0, -9.81);
-
-        // Ground plane at z=0
-        ground = dCreatePlane(space, 0, 0, 1, 0);
-    }
-
-    ~ODEPhysicsModule()
-    {
-        dJointGroupDestroy(contactgroup);
-        dSpaceDestroy(space);
-        dWorldDestroy(world);
-        dCloseODE();
-    }
-
-    /// Build the robot: body + 4 wheels + hinge‐motors + geoms
-    void createRobot()
-    {
-        // 1) chassis body
-        body = dBodyCreate(world);
-        dMass m;
-        dMassSetBoxTotal(&m, 1.0, 1.0, 1.0, 1.0);
-        dBodySetMass(body, &m);
-        dBodySetPosition(body, 0, 0, 1.0);
-
-        // geom for collisions
-        bodyGeom = dCreateBox(space, 1.0, 1.0, 1.0);
-        dGeomSetBody(bodyGeom, body);
-
-        // 2) wheels
-        for (int i = 0; i < 4; ++i) {
-            // physics body + mass
-            wheels[i] = dBodyCreate(world);
-            dMass mw;
-            dMassSetSphereTotal(&mw, 0.1, 0.2);
-            dBodySetMass(wheels[i], &mw);
-
-            // position them at the four corners
-            double x = (i % 2 == 0) ?  0.5 : -0.5;
-            double y = (i <  2) ?  0.5 : -0.5;
-            dBodySetPosition(wheels[i], x, y, 0.5);
-
-            // collision geom
-            wheelGeoms[i] = dCreateSphere(space, 0.2);
-            dGeomSetBody(wheelGeoms[i], wheels[i]);
-
-            // hinge joint: **axis = Y** for rolling forward/backward  ← FIX
-            joints[i] = dJointCreateHinge(world, 0);
-            dJointAttach(joints[i], body, wheels[i]);
-            dJointSetHingeAnchor(joints[i], x, y, 0.5);
-            dJointSetHingeAxis(joints[i], 0, 1, 0);   // ← FIX: horizontal axis
-
-            // give it a motor: target vel = 1 rad/s, max torque = 10 Nm
-            dJointSetHingeParam(joints[i], dParamVel, 1.0);
-            dJointSetHingeParam(joints[i], dParamFMax, 10.0);
-        }
-    }
-
-    /// Advance the physics by one fixed time step (10 ms)
-    void step()
-    {
-        // collide
-        dSpaceCollide(space, this, &ODEPhysicsModule::nearCallback);
-        // integrate
-        dWorldStep(world, 0.01);
-        // remove all temporary contact joints
-        dJointGroupEmpty(contactgroup);
-    }
-
-    // Getters for rendering sync:
-    const dReal* getBodyPosition()   const { return dBodyGetPosition(body);   }
-    const dReal* getBodyRotation()   const { return dBodyGetRotation(body);   }
-    const dReal* getWheelPosition(int i) const { return dBodyGetPosition(wheels[i]); }
-    const dReal* getWheelRotation(int i) const { return dBodyGetRotation(wheels[i]); }
-
-private:
-    /// ODE collision callback: create contact joints with friction/ERP/CFM
-    static void nearCallback(void* data, dGeomID o1, dGeomID o2)
-    {
-        ODEPhysicsModule* self = static_cast<ODEPhysicsModule*>(data);
-        dBodyID b1 = dGeomGetBody(o1);
-        dBodyID b2 = dGeomGetBody(o2);
-        if (b1 && b2 && dAreConnectedExcluding(b1, b2, dJointTypeContact))
-            return;
-
-        const int MAXC = 10;
-        dContact contact[MAXC];
-        int n = dCollide(o1, o2, MAXC, &contact[0].geom, sizeof(dContact));
-        if (n > 0) {
-            for (int i = 0; i < n; ++i) {
-                contact[i].surface.mode     = dContactSlip1     |
-                                               dContactSlip2     |
-                                               dContactSoftERP   |
-                                               dContactSoftCFM   |
-                                               dContactApprox1;
-                contact[i].surface.mu       = 0.5;
-                contact[i].surface.slip1    = 0.02;
-                contact[i].surface.slip2    = 0.02;
-                contact[i].surface.soft_erp = 0.1;
-                contact[i].surface.soft_cfm = 0.01;
-
-                // create the contact joint
-                dJointID c = dJointCreateContact(self->world,
-                                                  self->contactgroup,
-                                                  &contact[i]);
-                dJointAttach(c, b1, b2);
-            }
-        }
-    }
-
-    dWorldID       world;
-    dSpaceID       space;
-    dJointGroupID  contactgroup;
-    dGeomID        ground;
-
-    // chassis
-    dBodyID        body;
-    dGeomID        bodyGeom;
-
-    // wheels
-    dBodyID        wheels[4];
-    dGeomID        wheelGeoms[4];
-    dJointID       joints[4];
-};
+#endif
 
 /////////////////////////////////////////////////////////////////////
 /// Rendering module: wraps VSG, scene graph, and camera control ///
 /////////////////////////////////////////////////////////////////////
+#ifdef USE_VSG
 class VSGRenderingModule {
 public:
     vsg::ref_ptr<vsg::Viewer>   viewer;
@@ -224,10 +94,12 @@ public:
         }
     }
 };
+#endif // USE_VSG
 
 //////////////////////////////////////////////////////////////
 /// main: glue physics + rendering into a single loop     ///
 //////////////////////////////////////////////////////////////
+#ifdef USE_VSG
 int main(int /*argc*/, char** /*argv*/)
 {
     ODEPhysicsModule   physics;
@@ -248,3 +120,16 @@ int main(int /*argc*/, char** /*argv*/)
 
     return 0;
 }
+#else
+int main()
+{
+    ODEPhysicsModule physics;
+    physics.createRobot();
+    for (int i = 0; i < 100; ++i) {
+        physics.step();
+    }
+    const dReal* p = physics.getBodyPosition();
+    std::cout << "Final position: " << p[0] << ", " << p[1] << ", " << p[2] << std::endl;
+    return 0;
+}
+#endif


### PR DESCRIPTION
## Summary
- add CMake build system with optional VSG
- extract physics code to header and update example for optional rendering
- add headless test to exercise physics module
- expand README with build and test instructions

## Testing
- `cmake .. -DUSE_VSG=OFF`
- `make`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_6846ba77c05c8324b9e43df511652239

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a modular physics engine with a simple wheeled robot simulation using the ODE library.
  - Introduced a headless test mode to verify simulation correctness without graphical output.
  - Enabled optional graphical rendering using VulkanSceneGraph (VSG), configurable at build time.

- **Documentation**
  - Expanded README with detailed project description, build instructions, and usage guidance.

- **Refactor**
  - Separated physics logic into a standalone module for improved modularity and maintainability.
  - Updated simulation executable to support both graphical and headless modes based on build configuration.

- **Tests**
  - Added an automated test to ensure the simulated robot remains above ground level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->