### PR TITLE
Initialize ODE member pointers

### DIFF
--- a/include/ODEPhysicsModule.h
+++ b/include/ODEPhysicsModule.h
@@ -7,6 +7,8 @@
 class ODEPhysicsModule {
 public:
     ODEPhysicsModule()
+        : world(0), space(0), contactgroup(0), ground(0),
+          body(0), bodyGeom(0)
     {
         dInitODE();
         world        = dWorldCreate();
@@ -121,18 +123,18 @@ private:
         }
     }
 
-    dWorldID       world;
-    dSpaceID       space;
-    dJointGroupID  contactgroup;
-    dGeomID        ground;
+    dWorldID       world{};
+    dSpaceID       space{};
+    dJointGroupID  contactgroup{};
+    dGeomID        ground{};
 
     // chassis
-    dBodyID        body;
-    dGeomID        bodyGeom;
+    dBodyID        body{};
+    dGeomID        bodyGeom{};
 
     // wheels
-    dBodyID        wheels[4];
-    dGeomID        wheelGeoms[4];
-    dJointID       joints[4];
+    dBodyID        wheels[4]{};
+    dGeomID        wheelGeoms[4]{};
+    dJointID       joints[4]{};
 };
 


### PR DESCRIPTION
## Summary
- initialize ODE object pointers to zero to avoid analyzer warnings

## Testing
- `cmake .. -DUSE_VSG=OFF`
- `make -j$(nproc)`
- `ctest --output-on-failure`
- `./wheeled_simulation`

------
https://chatgpt.com/codex/tasks/task_e_6846c3420144832480cd1992aed3be23

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved initialization of internal physics module components to ensure more reliable default values and stability. No changes to user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->