### PR TITLE
Add sync test for physics->render transform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,3 +24,9 @@ add_executable(headless_test tests/headless_test.cpp)
 target_include_directories(headless_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_link_libraries(headless_test PRIVATE ${ODE_LIBRARIES})
 add_test(NAME headless COMMAND headless_test)
+
+# Synchronization test using a dummy rendering module
+add_executable(sync_test tests/sync_test.cpp)
+target_include_directories(sync_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+target_link_libraries(sync_test PRIVATE ${ODE_LIBRARIES})
+add_test(NAME sync COMMAND sync_test)

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ ctest
 ```
 
 The headless test runs a short simulation and verifies that the robot body
-remains above the ground.
+remains above the ground.  A second test checks that the rendering
+transforms produced from the physics state are properly synchronised.
 
 To run the graphical demo (with VSG installed):
 

--- a/tests/sync_test.cpp
+++ b/tests/sync_test.cpp
@@ -1,0 +1,63 @@
+#include "../include/ODEPhysicsModule.h"
+#include <cassert>
+#include <cmath>
+
+struct DummyTransform {
+    double matrix[16];
+};
+
+struct DummyRenderingModule {
+    DummyTransform bodyTransform;
+    DummyTransform wheelTransforms[4];
+
+    void update(const ODEPhysicsModule& physics) {
+        // chassis
+        const dReal* p = physics.getBodyPosition();
+        const dReal* R = physics.getBodyRotation();
+        setMatrix(bodyTransform.matrix, p, R);
+
+        // wheels
+        for (int i = 0; i < 4; ++i) {
+            p = physics.getWheelPosition(i);
+            R = physics.getWheelRotation(i);
+            setMatrix(wheelTransforms[i].matrix, p, R);
+        }
+    }
+
+    static void setMatrix(double m[16], const dReal* p, const dReal* R) {
+        m[0] = R[0];  m[1] = R[1];  m[2] = R[2];  m[3] = 0.0;
+        m[4] = R[4];  m[5] = R[5];  m[6] = R[6];  m[7] = 0.0;
+        m[8] = R[8];  m[9] = R[9];  m[10]= R[10]; m[11]= 0.0;
+        m[12]= p[0]; m[13]= p[1]; m[14]= p[2]; m[15]= 1.0;
+    }
+};
+
+int main() {
+    ODEPhysicsModule physics;
+    physics.createRobot();
+    for (int i = 0; i < 5; ++i) physics.step();
+
+    DummyRenderingModule renderer;
+    renderer.update(physics);
+
+    const dReal* p = physics.getBodyPosition();
+    const dReal* R = physics.getBodyRotation();
+
+    // Verify translation components
+    assert(std::abs(renderer.bodyTransform.matrix[12] - p[0]) < 1e-6);
+    assert(std::abs(renderer.bodyTransform.matrix[13] - p[1]) < 1e-6);
+    assert(std::abs(renderer.bodyTransform.matrix[14] - p[2]) < 1e-6);
+
+    // Verify a few rotation components
+    assert(std::abs(renderer.bodyTransform.matrix[0] - R[0]) < 1e-6);
+    assert(std::abs(renderer.bodyTransform.matrix[5] - R[5]) < 1e-6);
+    assert(std::abs(renderer.bodyTransform.matrix[10] - R[10]) < 1e-6);
+
+    // Wheel[0] translation should also match
+    p = physics.getWheelPosition(0);
+    assert(std::abs(renderer.wheelTransforms[0].matrix[12] - p[0]) < 1e-6);
+    assert(std::abs(renderer.wheelTransforms[0].matrix[13] - p[1]) < 1e-6);
+    assert(std::abs(renderer.wheelTransforms[0].matrix[14] - p[2]) < 1e-6);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add a new `sync_test` verifying rendering transforms are filled from ODE state
- wire the new test into CMake
- document the additional test in README

## Testing
- `cmake .. -DUSE_VSG=OFF`
- `make -j$(nproc)`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6847008a26388324b917a80972621616

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new synchronization test to verify that rendering transforms are correctly updated based on the physics simulation state.

- **Documentation**
  - Updated the README to clarify that test coverage now includes verification of rendering transform synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->